### PR TITLE
clean docfx favicon

### DIFF
--- a/_buildApi/BuildApiReference.proj
+++ b/_buildApi/BuildApiReference.proj
@@ -45,6 +45,8 @@
       <BuildApiRootFolder>$(MsBuildProjectDirectory)\BuildAPI</BuildApiRootFolder>
       <BuildApiSrcFolder>$(BuildApiRootFolder)\src</BuildApiSrcFolder>
       <SourceFolder>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..'))</SourceFolder>
+      <DocsSeedRoot>$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\..\..\</DocsSeedRoot>
+      <FavIconPath>$(DocsSeedRoot)\favicon.ico</FavIconPath>
       <DocsRepoName Condition="'$(DocsRepoName)' == '' ">Xamarin-Forms-docs</DocsRepoName>
       <DocsFolder>$(SourceFolder)\$(DocsRepoName)</DocsFolder>
       <DocsRepoApiAssetsFolder Condition="'$(DocsRepoApiAssetsFolder)' == '' ">_assets</DocsRepoApiAssetsFolder>
@@ -161,9 +163,9 @@
   </Target>
   
   <Target Name="DeleteDocFxFavicon">
-    <Delete Files="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\_site\favicon.ico" />
-    <Copy SourceFiles="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\..\..\favicon.ico" DestinationFolder="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\_site\" />
-    <Copy SourceFiles="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\..\..\favicon.ico" DestinationFolder="$(DocsRepoOutputFolder)" />
+    <Delete Files="$(BuildApiRootFolder)\_site\favicon.ico" />
+    <Copy SourceFiles="$(FavIconPath)" DestinationFolder="$(BuildApiRootFolder)\_site\" />
+    <Copy SourceFiles="$(FavIconPath)" DestinationFolder="$(DocsRepoOutputFolder)" />
   </Target>
 
 </Project>

--- a/_buildApi/BuildApiReference.proj
+++ b/_buildApi/BuildApiReference.proj
@@ -13,7 +13,8 @@
       RestoreNugetAPISolution;
       BuildAPISolution;
       ProcessSitemap;
-      CopyAPIHtmlFilesToSiteFolder 
+      DeleteDocFxFavicon;
+      CopyAPIHtmlFilesToSiteFolder
     </BuildApiReferenceDependsOn>
   </PropertyGroup>
 
@@ -157,6 +158,12 @@
     <Copy SourceFiles='@(ApiFiles)' DestinationFolder='$(DocsRepoOutputFolder)\api' />
     <Copy SourceFiles='@(ApiStyleFiles)' DestinationFolder='$(DocsRepoOutputFolder)\styles' />
 
+  </Target>
+  
+  <Target Name="DeleteDocFxFavicon">
+    <Delete Files="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\_site\favicon.ico" />
+    <Copy SourceFiles="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\..\..\favicon.ico" DestinationFolder="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\_site\" />
+    <Copy SourceFiles="$([System.IO.Path]::GetFullPath('$(BuildApiRootFolder)'))\..\..\favicon.ico" DestinationFolder="$(DocsRepoOutputFolder)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Their API ref build generates their own favicon.ico file in the `docs-seed\_buildApi\BuildAPI\_site` folder. Depending on how this is consumed by later builds, this may overwrite our own icon. Thus, at the end of the API ref build, but before copying assets to the docs repo, we will clean this icon and replace it with the original one we have.