### PR TITLE
fix: inconsistent behavior when scrolling to anchors

### DIFF
--- a/_assets/js/toc.js
+++ b/_assets/js/toc.js
@@ -44,16 +44,18 @@ $(function() {
             .addClass("anchor-" + this.tagName.toLowerCase());
     });
 
-    $("body").scrollspy({ target: ".article-toc", offset: NAVBAR_HEIGHT });
+    $("body").scrollspy({ target: ".article-toc", offset: SCROLLSPY_OFFSET });
 
     window.animateScrollTo = function(e) {
         e.preventDefault();
 
+        var currentScrollTop = $(window).scrollTop();
         var hash = this.hash;
-        var offset = $(this.hash).offset() || { top: $(document.body).scrollTop() };
+        var offset = $(this.hash).offset() || { top: currentScrollTop };
+        var scrollOffsetCorrection = currentScrollTop == 0 ? HEADER_HEIGHT + NAVBAR_HEIGHT : NAVBAR_HEIGHT;
 
         $('html, body').animate({
-            scrollTop: offset.top - NAVBAR_HEIGHT + 5
+            scrollTop: offset.top - scrollOffsetCorrection
         }, 500, function(){
             if (history.pushState) {
                 history.pushState(null, null, hash);

--- a/_assets/js/top-menu.js
+++ b/_assets/js/top-menu.js
@@ -1,4 +1,6 @@
-var NAVBAR_HEIGHT = 70;
 var HEADER_HEIGHT = 100;
+var TELERIKBAR_HEIGHT = 70;
+var NAVBAR_HEIGHT = 76;
+var SCROLLSPY_OFFSET = TELERIKBAR_HEIGHT + 10; // 10 compensates for the space above the anchored heading
 var FOOTER_DISTANCE = 20;
 var windowHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);


### PR DESCRIPTION
Animated scrolling behaved differently when starting from zero and non-zero scroll offset. The anchored heading was hidden when starting from zero scroll offset.