### PR TITLE
fix: inconsistent behavior when scrolling to anchors

### DIFF
--- a/_assets/js/api-toc.js
+++ b/_assets/js/api-toc.js
@@ -4,11 +4,13 @@ $(function () {
     window.animateScrollTo = function (e) {
         e.preventDefault();
 
+        var currentScrollTop = $(window).scrollTop();
         var hash = this.hash;
-        var offset = $(this.hash).offset() || { top: $(document.body).scrollTop() };
+        var offset = $(this.hash).offset() || { top: currentScrollTop };
+        var scrollOffsetCorrection = currentScrollTop == 0 ? HEADER_HEIGHT + NAVBAR_HEIGHT : NAVBAR_HEIGHT;
 
         $('html, body').animate({
-            scrollTop: offset.top - NAVBAR_HEIGHT + 5
+            scrollTop: offset.top - scrollOffsetCorrection
         }, 500, function () {
             if (history.pushState) {
                 history.pushState(null, null, hash);


### PR DESCRIPTION
Animated scrolling behaved differently when starting from zero and non-zero scroll offset. The anchored heading was hidden when starting from zero scroll offset.