### PR TITLE
add temp config for partial builds to gitignore

### DIFF
--- a/.contentignore
+++ b/.contentignore
@@ -31,3 +31,4 @@ search.html
 start-docs.sh
 watch.sh
 knowledge-base.html
+_tempconfig.yml


### PR DESCRIPTION
avoids an extra untracked file that does not ever need to be committed

Partially addresses #77