### PR TITLE
fix: Readjust anchor scroll offset on page load

### DIFF
--- a/_assets/js/api-toc.js
+++ b/_assets/js/api-toc.js
@@ -7,7 +7,15 @@ $(function () {
         e.preventDefault();
         animateScrolling(this.hash);
     };
-
+    
+    // Detect hash on page load and readjust scroll offset
+    var initialHash = window.location.hash;
+    if (!!initialHash) {
+        setTimeout(function(){
+          animateScrolling(initialHash);
+        }, 100);
+    }
+    
     $("#markdown-toc")
         .on("click", "a", function () {
             $(".section > ul").hide();

--- a/_assets/js/toc.js
+++ b/_assets/js/toc.js
@@ -52,7 +52,15 @@ $(function() {
         e.preventDefault();
         animateScrolling(this.hash);
     };
-
+    
+    // Detect hash on page load and readjust scroll offset
+    var initialHash = window.location.hash;
+    if (!!initialHash) {
+        setTimeout(function(){
+          animateScrolling(initialHash);
+        }, 100);
+    }
+    
     // animated scroll
     // Exclude the app inside the div.theme-preview since it's not in an <iframe/>,
     // leading to unwanted scrollTop when clicking on links inside the app.


### PR DESCRIPTION
The problem is related to browser scrolling to anchors, which occurs before our scripts are executed and before the page layout is adjusted. A CSS fix cannot be implemented, because it will require pushing the anchored heading down on page load, which is not possible. Hence, a JS workaround is suggested here. It checks if an anchor exists in the URL on page load and if so, scroll to it programmatically with a timeout.