### PR TITLE
Support custom Contact Support link.

### DIFF
--- a/_layouts/api-index.html
+++ b/_layouts/api-index.html
@@ -117,7 +117,11 @@ layout: default
     <div class="support-info-area">
       <span class="additional-info-content">Not finding the help you need?</span>
       <div>
+        {% if site.support_url %}
+        <a class="btn btn-action" href='{{ site.support_url }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
+        {% else %}
         <a class="btn btn-action" href='https://www.telerik.com/account/support-tickets?pid={{ site.data.support_products[site.product] }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
+        {% endif %}
       </div>
       {% if site.edit_repo_url and page.is_search_page != true and page.editable != false %}
       <a class="btn-edit-article" href="{{ site.edit_repo_url }}/{{ page.parent_path | replace: '.html','' }}.md" target="_blank">Improve this article</a>

--- a/_layouts/api-index.html
+++ b/_layouts/api-index.html
@@ -117,8 +117,8 @@ layout: default
     <div class="support-info-area">
       <span class="additional-info-content">Not finding the help you need?</span>
       <div>
-        {% if site.support_url %}
-        <a class="btn btn-action" href='{{ site.support_url }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
+        {% if site.contact_support_url %}
+        <a class="btn btn-action" href='{{ site.contact_support_url }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
         {% else %}
         <a class="btn btn-action" href='https://www.telerik.com/account/support-tickets?pid={{ site.data.support_products[site.product] }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
         {% endif %}

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -103,7 +103,11 @@ layout: default
     <div class="support-info-area">
       <span class="additional-info-content">Not finding the help you need?</span>
       <div>
+        {% if site.support_url %}
+        <a class="btn btn-action" href='{{ site.support_url }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
+        {% else %}
         <a class="btn btn-action" href='https://www.telerik.com/account/support-tickets?pid={{ site.data.support_products[site.product] }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
+        {% endif %}  
       </div>
       {% if site.edit_repo_url and page.is_search_page != true and page.editable != false %}
       <a class="btn-edit-article" href="{{ site.edit_repo_url }}/{{ page.path | replace: '.md','' }}.md" target="_blank">Improve this article</a>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -103,8 +103,8 @@ layout: default
     <div class="support-info-area">
       <span class="additional-info-content">Not finding the help you need?</span>
       <div>
-        {% if site.support_url %}
-        <a class="btn btn-action" href='{{ site.support_url }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
+        {% if site.contact_support_url %}
+        <a class="btn btn-action" href='{{ site.contact_support_url }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
         {% else %}
         <a class="btn btn-action" href='https://www.telerik.com/account/support-tickets?pid={{ site.data.support_products[site.product] }}' target="_blank" onclick="trackItemFromCurrentPage('docs-contact-support', '{{ site.product }}')">Contact support</a>
         {% endif %}  


### PR DESCRIPTION
E.g. for Fiddler we will use mail support and the link should open mail to support@getfiddler.com