### PR TITLE
chore: use new bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,4 +124,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.16.0
+   2.1.4


### PR DESCRIPTION
Apparently there is no bundler 1.16.1 anymore , we need to use 2.1.4