### PR TITLE
fix: incorrect scrollspy offset with new design

### DIFF
--- a/_assets/js/toc-base.js
+++ b/_assets/js/toc-base.js
@@ -1,28 +1,28 @@
 function animateScrolling(hash) {
-    var isApiSection = $("article.api-reference").length == 1;
-    var breadCrumbsElement = $("p.breadcrumbs");
-    var hasBreadCrumbs = breadCrumbsElement.length == 1 && breadCrumbsElement.text().trim() != "";
-    var currentScrollTop = $(window).scrollTop();
-    var offset = $(hash).offset() || { top: currentScrollTop };
+  var isApiSection = $("article.api-reference").length == 1;
+  var breadCrumbsElement = $("p.breadcrumbs");
+  var hasBreadCrumbs = breadCrumbsElement.length == 1 && breadCrumbsElement.text().trim() != "";
+  var currentScrollTop = $(window).scrollTop();
+  var offset = $(hash).offset() || { top: currentScrollTop };
 
-    var scrollOffsetCorrection = NAVBAR_HEIGHT;
-    if (currentScrollTop == 0) {
-      scrollOffsetCorrection += HEADER_HEIGHT;
-      if (hasBreadCrumbs) {
-        scrollOffsetCorrection += BREADCRUMBS_HEIGHT;
-      }
-      if (isApiSection) {
-        scrollOffsetCorrection += API_SCROLL_FIX;
-      }
+  var scrollOffsetCorrection = SCROLLSPY_OFFSET - 5; // not sure why 5px is needed
+  if (currentScrollTop == 0) {
+    scrollOffsetCorrection += 5; // not sure why 5px is needed
+    if (hasBreadCrumbs) {
+      scrollOffsetCorrection += BREADCRUMBS_HEIGHT;
     }
+    if (isApiSection) {
+      scrollOffsetCorrection += API_SCROLL_FIX;
+    }
+  }
 
-    $('html, body').animate({
-        scrollTop: offset.top - scrollOffsetCorrection
-    }, 500, function () {
-        if (history.pushState) {
-            history.pushState(null, null, hash);
-        } else {
-            window.location.hash = hash;
-        }
-    });
+  $('html, body').animate({
+      scrollTop: offset.top - scrollOffsetCorrection
+  }, 500, function () {
+      if (history.pushState) {
+          history.pushState(null, null, hash);
+      } else {
+          window.location.hash = hash;
+      }
+  });
 }

--- a/_assets/js/top-menu.js
+++ b/_assets/js/top-menu.js
@@ -1,8 +1,7 @@
-var HEADER_HEIGHT = 81;
-var TELERIKBAR_HEIGHT = 70;
-var NAVBAR_HEIGHT = 76;
+var TELERIKBAR_HEIGHT = 60;
+var SEARCHBAR_HEIGHT = 88;
 var BREADCRUMBS_HEIGHT = 20;
 var API_SCROLL_FIX = 40;
-var SCROLLSPY_OFFSET = TELERIKBAR_HEIGHT + 10; // 10 compensates for the space above the anchored heading
+var SCROLLSPY_OFFSET = TELERIKBAR_HEIGHT + SEARCHBAR_HEIGHT + 25; // 25px is for some space above the heading
 var FOOTER_DISTANCE = 20;
 var windowHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);


### PR DESCRIPTION
The new docs searchbar design broke the scrollspy functionality.

This fix is NOT TESTED with the Kendo UI API section. It's broken on live as well.