### PR TITLE
fix: 404 errors for Jessie sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.3.5
 
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list 
+RUN printf "deb http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list
 
 RUN apt-get -qq update && \
     apt-get -q -y upgrade && \


### PR DESCRIPTION
Debian Jessie is no longer supported and its sources are different.