### PR TITLE
Fix setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,75 +33,82 @@ This section describes how to run the documentation locally.
 ### Instructions (with Docker)
 
 1. Clone the current (seed) repo.
+  
   ```bash
   git clone git@github.com:telerik/docs-seed.git
   ```
 
-1. Go to the directory in which you've pulled it (for example, `D:\Work\docs-seed`).
-1. Open a terminal of your choice (for example, `gitBash`).
-1. Run the following command by passing the **DOCS-PATH** path (the **quotes** are mandatory):
+2. Go to the directory in which you've pulled it (for example, `D:\Work\docs-seed`).
+3. Open a terminal of your choice (for example, `gitBash`).
+4. Run the following command by passing the **DOCS-PATH** path (the **quotes** are mandatory):
+  
   ```bash
   sh copy_local.sh "D:\Work\xaml-docs"
   ```
 
   > If you are running the documentation on a macOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh` script: `sh copy_local.sh "D:\Work\xaml-docs" true`.
 
-1. Go to the **DOCS-PATH** directory.
-2. Open the `Dockerfile` with an editor
-3. Delete the following two rows:
-```
-ADD Gemfile ${APP_ROOT}/
-ADD Gemfile.lock ${APP_ROOT}/
-```
-4. Add the following row:
-```
-ENV BUNDLER_VERSION=2.1.4
-```
-5. Delete the `GemFile.lock` file
-6. Open a terminal of your choice (for example, `gitBash`).
-7. Execute the following bash command in the root folder (where the `Dockerfile` is located).
+5. Go to the **DOCS-PATH** directory.
+6. Open the `Dockerfile` with an editor
+7. Delete the following two rows:
+
+  ```
+  ADD Gemfile ${APP_ROOT}/
+  ADD Gemfile.lock ${APP_ROOT}/
+  ```
+
+8. Add the following row:
+
+  ```
+  ENV BUNDLER_VERSION=2.1.4
+  ```
+9. Delete the `GemFile.lock` file
+10. Open a terminal of your choice (for example, `gitBash`).
+11. Execute the following bash command in the root folder (where the `Dockerfile` is located).
+  
   ```bash
   sh start-docs.sh
   ```
 
-1. Open the documentation site on the server address shown in the terminal: `http://0.0.0.0:4000/`. If you can't open the URL, replace the `0.0.0.0` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://0.0.0.0:4000/devtools/wpf/`.
-
-1. To stop the web site and the container in which it has been served, navigate to the terminal in which you've executed the previous command, and press `CTRL+C`. On passing an additional `config` file for the WPF and Silverlight documentation, refer to [this section](#additional-config-file).
+12. Open the documentation site on the server address shown in the terminal: `http://0.0.0.0:4000/`. If you can't open the URL, replace the `0.0.0.0` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://0.0.0.0:4000/devtools/wpf/`.
+13. To stop the web site and the container in which it has been served, navigate to the terminal in which you've executed the previous command, and press `CTRL+C`. On passing an additional `config` file for the WPF and Silverlight documentation, refer to [this section](#additional-config-file).
 
 ### Instructions (without Docker)
 
 1. Install ruby 2.3.3 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3-x64.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3.exe)).
-1. Install Ruby DevKit 4.7.2 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe)). For more information, see the [Development Kit - Installation instructions](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#installation-instructions).
-1. Ensure that everything is installed correctly. This is a required step if you have previous versions installed on the machine (for example, check whether the `config.yml` file in the DevKit root folder contains the correct path to the ruby folder and check whether the system environment variables are correctly set). For more information, refer to [this article](http://jekyll-windows.juthilo.com/1-ruby-and-devkit/).
-1. Install bundler (if you have already installed, continue to the next step) by executing `gem install bundler`.
+2. Install Ruby DevKit 4.7.2 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe)). For more information, see the [Development Kit - Installation instructions](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#installation-instructions).
+3. Ensure that everything is installed correctly. This is a required step if you have previous versions installed on the machine (for example, check whether the `config.yml` file in the DevKit root folder contains the correct path to the ruby folder and check whether the system environment variables are correctly set). For more information, refer to [this article](http://jekyll-windows.juthilo.com/1-ruby-and-devkit/).
+4. Install bundler (if you have already installed, continue to the next step) by executing `gem install bundler`.
 
   > If you experience SSL errors with Bundler, similar to the one described in [RubyGems SSL Certificate Update](https://guides.rubygems.org/ssl-certificate-update/), then follow the solution steps shared in [Bundler.io - Installing new RubyGems certificates](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#installing-new-rubygems-certificates).
 
-1. Clone the current (seed) repo.
+5. Clone the current (seed) repo.
+
   ```bash
   git clone git@github.com:telerik/docs-seed.git
   ```
 
-1. Go to the directory in which you've pulled the current (seed) repo (for example, `D:\Work\docs-seed`).
-1. Open a terminal of your choice (for example, `gitBash`).
-1. Run the following command by passing the **DOCS-PATH** path (the **quotes** are mandatory):
+6. Go to the directory in which you've pulled the current (seed) repo (for example, `D:\Work\docs-seed`).
+7. Open a terminal of your choice (for example, `gitBash`).
+8. Run the following command by passing the **DOCS-PATH** path (the **quotes** are mandatory):
+
   ```bash
   sh copy_local.sh "D:\Work\xaml-docs"
   ```
 
   > If you are running the documentation on a macOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh script`: `sh copy_local.sh "D:\Work\xaml-docs" true`.
 
-1. Go to the **DOCS-PATH** directory.
-1. Open a terminal of your choice (for example, `gitBash`).
-1. Install gems by executing `bundle install`.
-1. Execute the following bash command in the root folder:
+9. Go to the **DOCS-PATH** directory.
+10. Open a terminal of your choice (for example, `gitBash`).
+11. Install gems by executing `bundle install`.
+12. Execute the following bash command in the root folder:
+  
   ```bash
   bundle exec jekyll serve
   ```
 
-1. Open the documentation site on the server address which is written in the terminal: `http://127.0.0.1:4000/`. If you can't open the URL, replace the `127.0.0.1` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://127.0.0.1:4000/devtools/wpf/`.
-
-1. To change the host or port, pass the `--host` or `--port` arguments to the command above as an addition (for example, `bundle exec jekyll serve --host=0.0.0.0 --port=1234`).
+13. Open the documentation site on the server address which is written in the terminal: `http://127.0.0.1:4000/`. If you can't open the URL, replace the `127.0.0.1` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://127.0.0.1:4000/devtools/wpf/`.
+14. To change the host or port, pass the `--host` or `--port` arguments to the command above as an addition (for example, `bundle exec jekyll serve --host=0.0.0.0 --port=1234`).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ Contains the documentation site implementation.
   * [Webinar Banner](#webinar-banner)
 - [Build API Reference](#build-api-reference)
 - [Documentation Best Practices](#documentation-best-practices)
-- [docs-seed Syntax Gudelines](#docs-seed-syntax-guidelines)
+- [docs-seed Syntax Guidelines](#docs-seed-syntax-guidelines)
 
 ## Local Setup
-This section describes the best practices about what and how needs to be done to run the documentation locally.
+This section describes how to run the documentation locally.
 
 ### Prerequisites
-- Install Docker (Community Edititon(CE) is enough): 
+- Install Docker (Community Edition(CE) is sufficient): 
   - Use the [official Docker installation guide](https://docs.docker.com/install/). Accept the default installation instructions (use Linux containers, and so on).     
 - Install [Node.js](https://nodejs.org/en/) and restart the machine.
 - Choose a repo you want to contribute to (for example, [https://github.com/telerik/xaml-docs.git](https://github.com/telerik/xaml-docs.git). We will refer to that repo later on as **'MY-REPO'**.
 - Pull the documentation repo onto your hard drive (for example, `"D:\Work\xaml-docs"`). We will refer to the local path, where the documentation repo is cloned, as **'DOCS-PATH'**.
 
-> * For products such as Kendo UI for jQuery, UI for ASP.NET MVC, and UI for ASP.NET Core, the documentation is part of source code repo. For these products, **'DOCS-PATH' is actually a nested folder** in the cloned repo, for example, `"D:\Work\kendo-ui-core\docs"`.
+> * For products such as Kendo UI for jQuery, UI for ASP.NET MVC, and UI for ASP.NET Core, the documentation is part of source code repo. For these products, **'DOCS-PATH' is a nested folder** in the cloned repo, for example, `"D:\Work\kendo-ui-core\docs"`.
 > * If you are not able to install and use Docker, go to [Instructions (without Docker)](#instructions-without-docker). Otherwise, continue to the next section.
 
 ### Instructions (with Docker)
@@ -40,7 +40,7 @@ This section describes the best practices about what and how needs to be done to
   sh copy_local.sh "D:\Work\xaml-docs"
   ```
 
-  > If you are running the documentation on a MacOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh` script: `sh copy_local.sh "D:\Work\xaml-docs" true`.
+  > If you are running the documentation on a macOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh` script: `sh copy_local.sh "D:\Work\xaml-docs" true`.
 
 1. Go to the **DOCS-PATH** directory.
 2. Open the `Dockerfile` with an editor
@@ -60,17 +60,17 @@ ENV BUNDLER_VERSION=2.1.4
   sh start-docs.sh
   ```
 
-1. Open the documentation site on the server address which is written in the terminal: `http://0.0.0.0:4000/`. If you can't open the URL, replace the `0.0.0.0` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://0.0.0.0:4000/devtools/wpf/`.
+1. Open the documentation site on the server address shown in the terminal: `http://0.0.0.0:4000/`. If you can't open the URL, replace the `0.0.0.0` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://0.0.0.0:4000/devtools/wpf/`.
 
 1. To stop the web site and the container in which it has been served, navigate to the terminal in which you've executed the previous command, and press `CTRL+C`. On passing an additional `config` file for the WPF and Silverlight documentation, refer to [this section](#additional-config-file).
 
 ### Instructions (without Docker)
-1. Install ruby 2.3.3 ([64bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3-x64.exe) or [32bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3.exe)).
-1. Install Ruby DevKit 4.7.2 ([64bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) or [32bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe)). For more informatin, see the [Development Kit - Installation instructions](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#installation-instructions).
-1. Ensure that everything is correctly installed especially if you have previous versions installed on the machine (for example, check whether the `config.yml` file in the DevKit root folder contains the correct path to the ruby folder and check whether the system environmnet variables are correctly set). For more information, refer to [this article](http://jekyll-windows.juthilo.com/1-ruby-and-devkit/).
+1. Install ruby 2.3.3 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3-x64.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3.exe)).
+1. Install Ruby DevKit 4.7.2 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe)). For more information, see the [Development Kit - Installation instructions](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#installation-instructions).
+1. Ensure that everything is installed correctly. This is a required step if you have previous versions installed on the machine (for example, check whether the `config.yml` file in the DevKit root folder contains the correct path to the ruby folder and check whether the system environment variables are correctly set). For more information, refer to [this article](http://jekyll-windows.juthilo.com/1-ruby-and-devkit/).
 1. Install bundler (if you have already installed, continue to the next step) by executing `gem install bundler`.
 
-  > If you encounter SSL errors with Bundler, similar to the one described in [RubyGems SSL Certificate Update](https://guides.rubygems.org/ssl-certificate-update/), then follow the solution steps shared in [Bundler.io - Installing new RubyGems certificates](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#installing-new-rubygems-certificates).
+  > If you experience SSL errors with Bundler, similar to the one described in [RubyGems SSL Certificate Update](https://guides.rubygems.org/ssl-certificate-update/), then follow the solution steps shared in [Bundler.io - Installing new RubyGems certificates](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#installing-new-rubygems-certificates).
 
 1. Clone the current (seed) repo.
   ```bash
@@ -84,7 +84,7 @@ ENV BUNDLER_VERSION=2.1.4
   sh copy_local.sh "D:\Work\xaml-docs"
   ```
 
-  > If you are running the documentation on a MacOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh script`: `sh copy_local.sh "D:\Work\xaml-docs" true`.
+  > If you are running the documentation on a macOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh script`: `sh copy_local.sh "D:\Work\xaml-docs" true`.
 
 1. Go to the **DOCS-PATH** directory.
 1. Open a terminal of your choice (for example, `gitBash`).
@@ -102,14 +102,14 @@ ENV BUNDLER_VERSION=2.1.4
 
 ### Get More Detailed Error Message
 
-To get more information and a full stacktrace of the error, add `--trace` after your jekyll command. For example, `bundle exec jekyll build --trace`.
+To get more information and a full stack trace of the error, add `--trace` after your `jekyll` command. For example, `bundle exec jekyll build --trace`.
 
 
 ### Does Not Serve
 
 You executed `sh start-docs.sh` but you did not see any Jekyll output. Instead, the command ended with `the input device is not a TTY. If you are using mintty, try prefixing the command with 'winpty'`.
 
-This happens whtn using Git Bash with the MinTTY console. This console does not allow combinations such as `Ctrl+C` to pass to the Docker container and that's why you get such an error.
+This happens when using Git Bash with the MinTTY console. This console does not allow combinations such as `Ctrl+C` to pass to the Docker container and that's why you get such an error.
 
 To solve this issue, prefix the command with `winpty`:
 
@@ -117,7 +117,7 @@ To solve this issue, prefix the command with `winpty`:
 winpty sh start-docs.sh
 ```
 
-Aa an alternative, re-install Git Bash and choose the default Windows terminal this time. For more detailes, refer to the [Docker for Windows: Interactive Sessions in MinTTY Git Bash](https://willi.am/blog/2016/08/08/docker-for-windows-interactive-sessions-in-mintty-git-bash/) post.
+Aa an alternative, re-install Git Bash and choose the default Windows terminal this time. For more details, refer to the [Docker for Windows: Interactive Sessions in MinTTY Git Bash](https://willi.am/blog/2016/08/08/docker-for-windows-interactive-sessions-in-mintty-git-bash/) post.
 
 ### Ctrl+C Does Not Work
 
@@ -125,7 +125,7 @@ When you want to stop serving the docs, you may have to repeat the `Ctrl+C` comm
 
 ### .gitignore Is always Modified
 
-The scripts that copy the seed repo to the content repo (**MY-REPO**) also update the `.gitignore` file to avoid creating unstanged changestogether with the work files that must not be commited. If you keep getting the `.gitignore` checked out, identify the changes as compared to the original and commit the version that matches what the tool generates to your repo.
+The scripts that copy the seed repo to the content repo (**MY-REPO**) also update the `.gitignore` file to avoid creating unstaged changes together with the work files that must not be committed. If you keep getting the `.gitignore` checked out, identify the changes as compared to the original and commit the version that matches what the tool generates to your repo.
 
 ### Performance
 
@@ -159,7 +159,7 @@ When you try to build the documentation site, you may see an error including the
 
 ## Extra Features
 
-You can benefit from the following features:
+You might find the following features useful:
 * [Additional config File](#additional-config-file)
 * [Live Sync](#livesync)
 * [Build without Serve](#only-build)
@@ -173,8 +173,10 @@ To add an additional `config.yml` file, pass it to the above command as follows:
 ```bash
 sh start-docs.sh _silverlight.yml
 ```
+
 ### LiveSync
-To be able to monitor the changes you are making on the built documentation, execute the following command in a new terminal in the root directory of the site:
+
+To monitor the changes you are making on the built documentation, execute the following command in a new terminal in the root directory of the site:
 ```bash
 sh watch.sh
 ```
@@ -195,15 +197,15 @@ This can be useful if you want to (or already have) set up a local IIS to point 
 
 To speed up the building time of the web site, you can pass **only** specific parts of it&mdash;the folders you want to include in the site. 
 
-To acieve this, execute the `sh modify-config.sh` script with passing the corresponding arguments which are:
+To achieve this, execute the `sh modify-config.sh` script with passing the corresponding arguments which are:
 
 - `-i,--include`&mdash;The folders you want to include in the final build. Multiple folders are separated with a comma. No spaces are allowed.
 - `-c,--config`&mdash;The path to an additional config file which will be used for the build (more about [additional config file](#additional-config-file)).
 - `-s,--serve`&mdash;Accepts `true`/`false`. Indicates whether the Jekyll will only build or build and serve.
-- `-d,--docker`&mdash;Accepts `true`/`false`. Indicates whether the site will be run in Docker (set `--docker=true` if you're using Docker).
+- `-d,--docker`&mdash;Accepts `true`/`false`. Indicates whether the site will run in Docker (set `--docker=true` if you're using Docker).
 
 
-For example, let's say that you want to build only the documentation for two controls, the Barcode and the Chart, you are using Docker, and you have an extra config YAML file. Then you have to open a terminal and execute the following command:
+For example, if you want to build only the documentation for two controls, the Barcode and the Chart, you are using Docker, and you have an extra config YAML file. Then you have to open a terminal and execute the following command:
 
 `sh modify-config.sh --include=controls/barcode,controls/Chart --docker=true --config=_extra.yml`
 
@@ -221,9 +223,9 @@ Moved in wiki under the [Announcements banner](https://github.com/telerik/docs-s
 
 ## Build API Reference
 
-There is an infrastructure that uses [DocFx](https://dotnet.github.io/docfx/) to generate an API reference portion of the site for you. To use it, you need the following:
+A [DocFX](https://dotnet.github.io/docfx/)-based infrastructure generates the API reference portion of the site for you. To use it, you need the following:
 
-* The docs-seed repo on your build machine. This should already be set up.
+* The docs-seed repo on your build machine.
 
 * An API ref link in your table of contents on the left. To enable it, add the following line in your `_config.yml` file: 
 
@@ -233,13 +235,13 @@ There is an infrastructure that uses [DocFx](https://dotnet.github.io/docfx/) to
         
 * A folder on a shared network location that the build can access, and that contains the `.dll` and `.xml` files you want generated.
 
-* The assets for building the API reference in your repo. You can start by copying existing assets, for example, [from Winforms](https://github.com/telerik/winforms-docs/tree/master/_assetsApi). Note that the templates are plain HTML for the time being, so you must keep them in sync with your actual repo code manually: update the footer template with the generated HTML of your own docs, make sure the search template can reach the scripts it needs (can be an issue mostly if you have cache busting enabled in your own repo). Also, update the `index.md` file to have the contents suitable for your case. Keep them updated if you change your own repo as well.
+* The assets for building the API reference in your repo. You can start by copying existing assets, for example, [from WinForms](https://github.com/telerik/winforms-docs/tree/master/_assetsApi). Note that the templates are plain HTML for the time being, so you must keep them in sync with your repo code manually: update the footer template with the generated HTML of your own docs, make sure the search template can reach the scripts it needs (can be an issue if you have cache busting enabled in your own repo). Also, update the `index.md` file to have the contents suitable for your case. Keep them updated if you change your own repo as well.
 
-* An `MSBuild` step in your content repo builds that will take the binaries, xml files and content repo, build the HTML files for the API ref, and copy them to the `_site/api` folder in your content repo.
+* An `MSBuild` step in your content repo builds that will take the binaries, XML files and content repo, build the HTML files for the API ref, and copy them to the `_site/api` folder in your content repo.
 
     This build is executed through the [`_buildApi/BuildApiReference.proj`](https://github.com/telerik/docs-seed/blob/master/_buildApi/BuildApiReference.proj) file. For example, in the VS command prompt: `msbuild.exe BuildApiReference.proj /p:LatestBinariesPath=\\\\someNetworkServer\MySourceFiles;DocsRepoName=blazor-docs;DocumentationBaseUrl=https://docs.telerik.com/blazor-ui;DocsRepoApiAssetsFolder=_assetsApi;HasApiFilter=true`.
      
-     >note Depending on the machine culture, you might need to use a comma `,` instead of a semi-colon `;` otherwise you will get a _DocsRepoName is not defined_ error
+     >note Depending on the machine culture, you might need to use a comma `,` instead of a semi-colon `;` otherwise you will get a `DocsRepoName is not defined` error
            ```
            (CheckRequiredProperties target) ->
               D:\DocsSeed\_buildApi\BuildApiReference.proj(26,5): error : DocsRepoName is not defined (Ex. winforms-docs)
@@ -247,15 +249,15 @@ There is an infrastructure that uses [DocFx](https://dotnet.github.io/docfx/) to
            
     Here is a list of the build parameters and their purpose:
     
-    * `LatestBinariesPath`&mdash;The path to where you have the `.dll`+`.xml` pairs of code you want documented. The format is usually something like `\\\\someNetworkServer\MySourceFiles` or `C:\work\myFolder`. The escaping of the backslashes is an example for using this as a build parameter.
+    * `LatestBinariesPath`&mdash;The path to where you have the `.dll`+`.xml` pairs of code you want documented. The format is usually resembles `\\\\someNetworkServer\MySourceFiles` or `C:\work\myFolder`. The escaping of the backslashes is an example for using this as a build parameter.
     
-    * `DocsRepoName`&mdash;The name of the repo with your actual contents. The build assumes the docs-seed repo and the content repo are in adjacent folders. So, it is, for example just `blazor-docs` or `winforms-docs`, or `teststudio/docs` (when the docs are nested further down in a folder inside your repo).
+    * `DocsRepoName`&mdash;The name of the repo with your contents. By default, the build expects that the docs-seed repo and the content repo are located in adjacent folders.  So, for example, pass only `blazor-docs` or `winforms-docs`, or `teststudio/docs` (when the docs are nested further down in a folder inside your repo).
     
     * `DocumentationBaseUrl`&mdash;The base URL of your docs when on the live server. Used for the `sitemap.xml` file. For example, `https://docs.telerik.com/blazor-ui/`.
     
-    * `DocsRepoApiAssetsFolder`&mdash;This is where the build assets specific to your repo reside (at the time of writing, search, footer templates, feedback form, plus a little of bit of styles). If you copy from an existing repo, this would always be `_assetsApi`.
+    * `DocsRepoApiAssetsFolder`&mdash;This is the location for the build assets specific to your repo (at the time of writing, search, footer templates, feedback form, plus some styles). If you copy from an existing repo, this is always `_assetsApi`.
     
-    * `HasApiFilter`&mdash;An `optional` parameter in case you want to avoid generating API reference docs for certain classes or their members. See the [DocFx docs on the matter](https://dotnet.github.io/docfx/tutorial/howto_filter_out_unwanted_apis_attributes.html) for syntax and examples. To use this filter, you must add a file in your repo with the desired filter contents, and put it in `<DocsRepoApiAssetsFolder>\filterConfig.yml`. The file is always at the root of the API assets folder, and is always called `filterConfig.yml`. Here's what docfx generate at the time of writing (10 Jul 2019, docfx version 2.40.5):
+    * `HasApiFilter`&mdash;An `optional` parameter in case you want to avoid generating API reference docs for some classes or their members. See the [DocFX docs on the matter](https://dotnet.github.io/docfx/tutorial/howto_filter_out_unwanted_apis_attributes.html) for syntax and examples. To use this filter, you must add a file in your repo with the desired filter contents, and put it in `<DocsRepoApiAssetsFolder>\filterConfig.yml`. The file is always at the root of the API assets folder, and is always called `filterConfig.yml`. Here's what DocFX generates at the time of writing (10 Jul 2019, DocFX version 2.40.5):
     
       **C#**
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This section describes how to run the documentation locally.
 
   > You can use Docker Community Edition (CE).
 
-2. Clone the current (seed) repo.
+2. Clone the **docs-seed** repo.
   
   ```bash
   git clone git@github.com:telerik/docs-seed.git

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ ENV BUNDLER_VERSION=2.1.4
 1. To stop the web site and the container in which it has been served, navigate to the terminal in which you've executed the previous command, and press `CTRL+C`. On passing an additional `config` file for the WPF and Silverlight documentation, refer to [this section](#additional-config-file).
 
 ### Instructions (without Docker)
+
 1. Install ruby 2.3.3 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3-x64.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3.exe)).
 1. Install Ruby DevKit 4.7.2 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe)). For more information, see the [Development Kit - Installation instructions](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#installation-instructions).
 1. Ensure that everything is installed correctly. This is a required step if you have previous versions installed on the machine (for example, check whether the `config.yml` file in the DevKit root folder contains the correct path to the ruby folder and check whether the system environment variables are correctly set). For more information, refer to [this article](http://jekyll-windows.juthilo.com/1-ruby-and-devkit/).
@@ -103,7 +104,6 @@ ENV BUNDLER_VERSION=2.1.4
 ### Get More Detailed Error Message
 
 To get more information and a full stack trace of the error, add `--trace` after your `jekyll` command. For example, `bundle exec jekyll build --trace`.
-
 
 ### Does Not Serve
 
@@ -148,7 +148,6 @@ When you try to build the documentation site, you may see an error including the
   * `LANG: en_GB.UTF-8`
 1. Modify the `runtimes.rb` file in the `execJs` gem by changing the `UTF-16LE` with the `UTF-8` value. For details, [see the instructions here](https://stackoverflow.com/questions/25830561/incomplete-n-on-utf-16le-error) or [here](https://stackoverflow.com/questions/12520456/execjsruntimeerror-on-windows-trying-to-follow-rubytutorial). The `runtimes.rb` file is located in `[Ruby Installation folder]\lib\ruby\gems\2.3.0\gems\execjs-2.7.0\lib\execjs`.
 
-
 ### Known Error Messages
 
 * `jekyll 3.3.1 | Error:  [prev_next plugin] Comparing the pages notes.md and sitemap.xml failed`
@@ -192,7 +191,6 @@ sh build-docs.sh
 
 This can be useful if you want to (or already have) set up a local IIS to point to the `_site` folder in your documentation repo. This allows you to also test redirects that `jekyll serve` does not support.
 
-
 ### Build Site Partially
 
 To speed up the building time of the web site, you can pass **only** specific parts of it&mdash;the folders you want to include in the site. 
@@ -204,11 +202,9 @@ To achieve this, execute the `sh modify-config.sh` script with passing the corre
 - `-s,--serve`&mdash;Accepts `true`/`false`. Indicates whether the Jekyll will only build or build and serve.
 - `-d,--docker`&mdash;Accepts `true`/`false`. Indicates whether the site will run in Docker (set `--docker=true` if you're using Docker).
 
-
 For example, if you want to build only the documentation for two controls, the Barcode and the Chart, you are using Docker, and you have an extra config YAML file. Then you have to open a terminal and execute the following command:
 
 `sh modify-config.sh --include=controls/barcode,controls/Chart --docker=true --config=_extra.yml`
-
 
 ### Exclude Articles from Navigation Tree
 
@@ -219,7 +215,6 @@ For example, from `https://github.com/telerik/ajax-docs/blob/master/_config.yml#
 ### Webinar Banner
 
 Moved in wiki under the [Announcements banner](https://github.com/telerik/docs-seed/wiki/Yellow-ribbon-banner-for-announcements#announcements-banner) article.
-
 
 ## Build API Reference
 
@@ -270,7 +265,6 @@ A [DocFX](https://dotnet.github.io/docfx/)-based infrastructure generates the AP
           private string privateTest;
           internal string internalTest;
           private protected string privateProtectedTest;
-
 
 ## Documentation Best Practices
 

--- a/README.md
+++ b/README.md
@@ -21,76 +21,51 @@ This section describes how to run the documentation locally.
 
 ### Prerequisites
 
-- Install Docker (Community Edition(CE) is sufficient):
-  - Use the [official Docker installation guide](https://docs.docker.com/install/). Accept the default installation instructions (use Linux containers, and so on).
 - Install [Node.js](https://nodejs.org/en/) and restart the machine.
-- Choose a repo you want to contribute to (for example, [https://github.com/telerik/xaml-docs.git](https://github.com/telerik/xaml-docs.git)). We will refer to that repo later on as **'MY-REPO'**.
-- Pull the documentation repo onto your hard drive (for example, `"D:\Work\xaml-docs"`). We will refer to the local path, where the documentation repo is cloned, as **'DOCS-PATH'**.
+- Choose a documentation repo to which you want to contribute. For example, [https://github.com/telerik/xaml-docs.git](https://github.com/telerik/xaml-docs.git).<br/>**MY-REPO** below.
+- Pull the documentation repo locally. For example, `"D:\Work\xaml-docs"`.<br/>Referred to as **DOCS-PATH** below.
 
-> * For products such as Kendo UI for jQuery, UI for ASP.NET MVC, and UI for ASP.NET Core, the documentation is part of source code repo. For these products, **'DOCS-PATH' is a nested folder** in the cloned repo, for example, `"D:\Work\kendo-ui-core\docs"`.
-> * If you are not able to install and use Docker, go to [Instructions (without Docker)](#instructions-without-docker). Otherwise, continue to the next section.
-
-### Instructions (with Docker)
-
-1. Clone the current (seed) repo.
-  
-  ```bash
-  git clone git@github.com:telerik/docs-seed.git
-  ```
-
-2. Go to the directory in which you've pulled it (for example, `D:\Work\docs-seed`).
-3. Open a terminal of your choice (for example, `gitBash`).
-4. Run the following command by passing the **DOCS-PATH** path (the **quotes** are mandatory):
-  
-  ```bash
-  sh copy_local.sh "D:\Work\xaml-docs"
-  ```
-
-  > If you are running the documentation on a macOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh` script: `sh copy_local.sh "D:\Work\xaml-docs" true`.
-
-5. Go to the **DOCS-PATH** directory.
-6. Open the `Dockerfile` with an editor
-7. Delete the following two rows:
-
-  ```
-  ADD Gemfile ${APP_ROOT}/
-  ADD Gemfile.lock ${APP_ROOT}/
-  ```
-
-8. Add the following row:
-
-  ```
-  ENV BUNDLER_VERSION=2.1.4
-  ```
-9. Delete the `GemFile.lock` file
-10. Open a terminal of your choice (for example, `gitBash`).
-11. Execute the following bash command in the root folder (where the `Dockerfile` is located).
-  
-  ```bash
-  sh start-docs.sh
-  ```
-
-12. Open the documentation site on the server address shown in the terminal: `http://0.0.0.0:4000/`. If you can't open the URL, replace the `0.0.0.0` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://0.0.0.0:4000/devtools/wpf/`.
-13. To stop the web site and the container in which it has been served, navigate to the terminal in which you've executed the previous command, and press `CTRL+C`. On passing an additional `config` file for the WPF and Silverlight documentation, refer to [this section](#additional-config-file).
+> * For products such as Kendo UI for jQuery, UI for ASP.NET MVC, and UI for ASP.NET Core, the documentation is part of the source code repo. For these products, **'DOCS-PATH' is a nested folder** in the cloned repo, for example, `"D:\Work\kendo-ui-core\docs"`.
 
 ### Instructions (without Docker)
 
-1. Install ruby 2.3.3 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3-x64.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3.exe)).
-2. Install Ruby DevKit 4.7.2 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe)). For more information, see the [Development Kit - Installation instructions](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#installation-instructions).
-3. Ensure that everything is installed correctly. This is a required step if you have previous versions installed on the machine (for example, check whether the `config.yml` file in the DevKit root folder contains the correct path to the ruby folder and check whether the system environment variables are correctly set). For more information, refer to [this article](http://jekyll-windows.juthilo.com/1-ruby-and-devkit/).
-4. Install bundler (if you have already installed, continue to the next step) by executing `gem install bundler`.
+1. Install Ruby 2.3.3 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3-x64.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/ruby-2.3.3/rubyinstaller-2.3.3.exe)).
 
-  > If you experience SSL errors with Bundler, similar to the one described in [RubyGems SSL Certificate Update](https://guides.rubygems.org/ssl-certificate-update/), then follow the solution steps shared in [Bundler.io - Installing new RubyGems certificates](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#installing-new-rubygems-certificates).
+  > Select `Add Ruby executables to your PATH` and `Associate .rb and .rbw files with this Ruby installation` during the installation.
 
-5. Clone the current (seed) repo.
+2. Download and extract the Ruby DevKit 4.7.2 ([64-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) or [32-bit](https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe)). Note the location of the extracted archive (for example: `C:\RubyDevKit`).
+
+3. Install and init the Ruby DevKit. For more information, see [here](http://jekyll-windows.juthilo.com/1-ruby-and-devkit/).
+
+  ```bash
+  cd C:\RubyDevKit
+  ruby dk.rb init
+  ruby dk.rb install 
+  ```
+
+4. Install RubyGems 3.2.29.
+
+  ```bash
+  gem update --system 3.2.29
+  ```
+
+5. Install Bundler 2.3.11.
+
+  ```bash
+  gem install bundler -v 2.3.11
+  ```
+
+  > If you experience SSL errors with Bundler, similar to the one described in [RubyGems SSL Certificate Update](https://guides.rubygems.org/ssl-certificate-update/), follow the solution steps from [Bundler.io - Installing new RubyGems certificates](https://bundler.io/guides/rubygems_tls_ssl_troubleshooting_guide.html#installing-new-rubygems-certificates).
+
+6. Clone the **docs-seed** repo.
 
   ```bash
   git clone git@github.com:telerik/docs-seed.git
   ```
 
-6. Go to the directory in which you've pulled the current (seed) repo (for example, `D:\Work\docs-seed`).
-7. Open a terminal of your choice (for example, `gitBash`).
-8. Run the following command by passing the **DOCS-PATH** path (the **quotes** are mandatory):
+7. Go to the directory for the pulled **docs-seed** repo (for example, `D:\Work\docs-seed`).
+8. Open your preferred Bash-enabled terminal (for example, `gitBash`).
+9. Run the following command and pass the **DOCS-PATH** path (the **quotes** are mandatory):
 
   ```bash
   sh copy_local.sh "D:\Work\xaml-docs"
@@ -98,17 +73,79 @@ This section describes how to run the documentation locally.
 
   > If you are running the documentation on a macOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh script`: `sh copy_local.sh "D:\Work\xaml-docs" true`.
 
-9. Go to the **DOCS-PATH** directory.
-10. Open a terminal of your choice (for example, `gitBash`).
-11. Install gems by executing `bundle install`.
-12. Execute the following bash command in the root folder:
+10. In the terminal, navigate to the **DOCS-PATH** directory.
+
+  ```bash
+  cd D:\Work\xaml-docs
+  ```
+
+11. Install the required dependencies:
+  
+  ```bash
+  bundle install 
+  ```
+
+12. Run the following command in the root folder of the cloned documentation repo:
   
   ```bash
   bundle exec jekyll serve
   ```
 
-13. Open the documentation site on the server address which is written in the terminal: `http://127.0.0.1:4000/`. If you can't open the URL, replace the `127.0.0.1` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://127.0.0.1:4000/devtools/wpf/`.
-14. To change the host or port, pass the `--host` or `--port` arguments to the command above as an addition (for example, `bundle exec jekyll serve --host=0.0.0.0 --port=1234`).
+13. In your browser, navigate to the server address shown in the terminal: `http://127.0.0.1:4000/`.<br/>For documentation sets nested in the documentation repo, you need to navigate to the respective folder. For example, for the WPF documentation, the correct server address will be `http://127.0.0.1:4000/devtools/wpf/`.
+
+  > If you can't open the URL, replace the `127.0.0.1` with `localhost` (`http://localhost:4000`).
+
+  > If you want to change the host or port, pass the `--host` or `--port` arguments to the command from **Step 12**. For example, `bundle exec jekyll serve --host=0.0.0.0 --port=1234`.
+
+### Instructions (with Docker)
+
+> **Caution**
+> As of November 2023, the support for the docs-seed setup via Docker is limited. See [Instructions (without Docker)](#instructions-without-docker) instead.
+
+1. Ensure that you have installed Docker with the default settings enabled. See the [official Docker installation guide](https://docs.docker.com/install/).
+
+  > You can use Docker Community Edition (CE).
+
+2. Clone the current (seed) repo.
+  
+  ```bash
+  git clone git@github.com:telerik/docs-seed.git
+  ```
+
+3. Go to the directory in which you've pulled it (for example, `D:\Work\docs-seed`).
+4. Open a terminal of your choice (for example, `gitBash`).
+5. Run the following command by passing the **DOCS-PATH** path (the **quotes** are mandatory):
+  
+  ```bash
+  sh copy_local.sh "D:\Work\xaml-docs"
+  ```
+
+  > If you are running the documentation on a macOS or another OS where the `robocopy` command is unavailable, pass a second parameter to the `copy_local.sh` script: `sh copy_local.sh "D:\Work\xaml-docs" true`.
+
+6. Go to the **DOCS-PATH** directory.
+7. Open the `Dockerfile` with an editor
+8. Delete the following two rows:
+
+  ```
+  ADD Gemfile ${APP_ROOT}/
+  ADD Gemfile.lock ${APP_ROOT}/
+  ```
+
+9. Add the following row:
+
+  ```
+  ENV BUNDLER_VERSION=2.1.4
+  ```
+10. Delete the `GemFile.lock` file
+11. Open a terminal of your choice (for example, `gitBash`).
+12. Execute the following bash command in the root folder (where the `Dockerfile` is located).
+  
+  ```bash
+  sh start-docs.sh
+  ```
+
+13. Open the documentation site on the server address shown in the terminal: `http://0.0.0.0:4000/`. If you can't open the URL, replace the `0.0.0.0` with `localhost`: `http://localhost:4000`. For example, for the WPF documentation, this will be `http://0.0.0.0:4000/devtools/wpf/`.
+14. To stop the web site and the container in which it has been served, navigate to the terminal in which you've executed the previous command, and press `CTRL+C`. On passing an additional `config` file for the WPF and Silverlight documentation, refer to [this section](#additional-config-file).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This section describes how to run the documentation locally.
 ### Prerequisites
 
 - Install [Node.js](https://nodejs.org/en/) and restart the machine.
-- Choose a documentation repo to which you want to contribute. For example, [https://github.com/telerik/xaml-docs.git](https://github.com/telerik/xaml-docs.git).<br/>**MY-REPO** below.
+- Choose a documentation repo to which you want to contribute. For example, [https://github.com/telerik/xaml-docs.git](https://github.com/telerik/xaml-docs.git).<br/>Referred to as **MY-REPO** below.
 - Pull the documentation repo locally. For example, `"D:\Work\xaml-docs"`.<br/>Referred to as **DOCS-PATH** below.
 
 > * For products such as Kendo UI for jQuery, UI for ASP.NET MVC, and UI for ASP.NET Core, the documentation is part of the source code repo. For these products, **'DOCS-PATH' is a nested folder** in the cloned repo, for example, `"D:\Work\kendo-ui-core\docs"`.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Contains the documentation site implementation.
 This section describes how to run the documentation locally.
 
 ### Prerequisites
-- Install Docker (Community Edition(CE) is sufficient): 
-  - Use the [official Docker installation guide](https://docs.docker.com/install/). Accept the default installation instructions (use Linux containers, and so on).     
+- Install Docker (Community Edition(CE) is sufficient):
+  - Use the [official Docker installation guide](https://docs.docker.com/install/). Accept the default installation instructions (use Linux containers, and so on).
 - Install [Node.js](https://nodejs.org/en/) and restart the machine.
-- Choose a repo you want to contribute to (for example, [https://github.com/telerik/xaml-docs.git](https://github.com/telerik/xaml-docs.git). We will refer to that repo later on as **'MY-REPO'**.
+- Choose a repo you want to contribute to (for example, [https://github.com/telerik/xaml-docs.git](https://github.com/telerik/xaml-docs.git)). We will refer to that repo later on as **'MY-REPO'**.
 - Pull the documentation repo onto your hard drive (for example, `"D:\Work\xaml-docs"`). We will refer to the local path, where the documentation repo is cloned, as **'DOCS-PATH'**.
 
 > * For products such as Kendo UI for jQuery, UI for ASP.NET MVC, and UI for ASP.NET Core, the documentation is part of source code repo. For these products, **'DOCS-PATH' is a nested folder** in the cloned repo, for example, `"D:\Work\kendo-ui-core\docs"`.
@@ -154,7 +154,7 @@ When you try to build the documentation site, you may see an error including the
   * Usually happens when a new article does not have `position` property in the front-matter. To solve this issue, add a number to the `position` property. If you want some articles to sort alphabetically, they need to have the same `position` value.
   * It might also happen if a folder or a file is magically added to the docs repo folder. To solve this issue, clean the folder and make a fresh clone of the docs repo.
 
-* `jekyll 3.3.1 | Error: 404 Not Found`&mdash;This is often observed when you create a new documentations and when no entry for the product in the Top Navigation list exists. To solve this issue, add an entry for your documentation as in the [feat: add MAUI to top navigation](https://github.com/telerik/docs-seed/commit/454d3178dbe65caa1e84b248206a514e4227d995#diff-96a33d63722834501d92ed56323571da7dd726397623401a2a25f4ac6610a553) commit for the `/_plugins/top_navigation.rb` file. If the Telerik Web Team do not have the Top Navigation ready yet, you can temporarily reuse the top navigation value property from another product to make the build successful. 
+* `jekyll 3.3.1 | Error: 404 Not Found`&mdash;This is often observed when you create a new documentations and when no entry for the product in the Top Navigation list exists. To solve this issue, add an entry for your documentation as in the [feat: add MAUI to top navigation](https://github.com/telerik/docs-seed/commit/454d3178dbe65caa1e84b248206a514e4227d995#diff-96a33d63722834501d92ed56323571da7dd726397623401a2a25f4ac6610a553) commit for the `/_plugins/top_navigation.rb` file. If the Telerik Web Team do not have the Top Navigation ready yet, you can temporarily reuse the top navigation value property from another product to make the build successful.
 
 ## Extra Features
 
@@ -193,7 +193,7 @@ This can be useful if you want to (or already have) set up a local IIS to point 
 
 ### Build Site Partially
 
-To speed up the building time of the web site, you can pass **only** specific parts of it&mdash;the folders you want to include in the site. 
+To speed up the building time of the web site, you can pass **only** specific parts of it&mdash;the folders you want to include in the site.
 
 To achieve this, execute the `sh modify-config.sh` script with passing the corresponding arguments which are:
 
@@ -222,7 +222,7 @@ A [DocFX](https://dotnet.github.io/docfx/)-based infrastructure generates the AP
 
 * The docs-seed repo on your build machine.
 
-* An API ref link in your table of contents on the left. To enable it, add the following line in your `_config.yml` file: 
+* An API ref link in your table of contents on the left. To enable it, add the following line in your `_config.yml` file:
 
     `_config.yml`
     
@@ -268,10 +268,10 @@ A [DocFX](https://dotnet.github.io/docfx/)-based infrastructure generates the AP
 
 ## Documentation Best Practices
 
-If you need to create new documentation (for example, for a new product), use [`docs-content-seed`](https://github.com/telerik/docs-content-seed) repository as an auxiliary part to this one. 
+If you need to create new documentation (for example, for a new product), use [`docs-content-seed`](https://github.com/telerik/docs-content-seed) repository as an auxiliary part to this one.
 
-For best practices and industry standards on creating and maintaining documentation, go to the public [Progress DevTools Style Guide](https://docs.telerik.com/style-guide/introduction).   
+For best practices and industry standards on creating and maintaining documentation, go to the public [Progress DevTools Style Guide](https://docs.telerik.com/style-guide/introduction).
 
-## docs-seed Syntax Guidelines  
+## docs-seed Syntax Guidelines
 
-To ensure the syntax you use when you add or edit the documentation will properly render the content, read the [syntax guidelines in the docs-seed Wiki](https://github.com/telerik/docs-seed/wiki/Handling-Redirects). 
+To ensure the syntax you use when you add or edit the documentation will properly render the content, read the [syntax guidelines in the docs-seed Wiki](https://github.com/telerik/docs-seed/wiki/Handling-Redirects).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # docs-seed repo
+
 Contains the documentation site implementation.
 
 - [Local Setup :computer:](#local-setup)
@@ -15,9 +16,11 @@ Contains the documentation site implementation.
 - [docs-seed Syntax Guidelines](#docs-seed-syntax-guidelines)
 
 ## Local Setup
+
 This section describes how to run the documentation locally.
 
 ### Prerequisites
+
 - Install Docker (Community Edition(CE) is sufficient):
   - Use the [official Docker installation guide](https://docs.docker.com/install/). Accept the default installation instructions (use Linux containers, and so on).
 - Install [Node.js](https://nodejs.org/en/) and restart the machine.
@@ -28,6 +31,7 @@ This section describes how to run the documentation locally.
 > * If you are not able to install and use Docker, go to [Instructions (without Docker)](#instructions-without-docker). Otherwise, continue to the next section.
 
 ### Instructions (with Docker)
+
 1. Clone the current (seed) repo.
   ```bash
   git clone git@github.com:telerik/docs-seed.git


### PR DESCRIPTION
* Move Docker instructions lower on the page due to limited support
* Add Caution callout to the Docker instructions (for the limited support)
* Update the non-Docker instructions with missing versions (the noted versions were required to make a clean install on Windows 11)
* Fix a few minor issues with empty lines and unnecessary spaces
* Fix list issues (it seems that GitHub doesn't process lists with nested code blocks and callouts properly and breaks the list, if using just `1s`)
* Apply fixes after ReDox run