### PR TITLE
chore: update feedback-form cdn

### DIFF
--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -3,8 +3,10 @@
 {% else %}
 {% assign icon = "DevCraft" %}
 {% endif %}
-<script src="https://d3fu8oi3wk1rz4.cloudfront.net/kendo-docs-demos-assets/2.2.2/scripts/feedback-form/index.min.js?{{randomNumber}}" defer></script>
-<feedback-form sheet-id="{{site.ff-sheet-id}}"  
-                kinvey-app-key="{% if site.environment == 'test' or site.environment == 'dev' %}kid_ryLIO7OtI{% else %}kid_Hk57KwIFf{% endif %}" 
-                icon-url="{{ site.baseurl }}/assets/Avatar-{{ icon }}-big.svg">
+<script
+    src="https://d3fu8oi3wk1rz4.cloudfront.net/kendo-docs-demos-assets/2.3.6/scripts/feedback-form/index.min.js?{{randomNumber}}"
+    defer></script>
+<feedback-form sheet-id="{{site.ff-sheet-id}}"
+    kinvey-app-key="{% if site.environment == 'test' or site.environment == 'dev' %}kid_ryLIO7OtI{% else %}kid_Hk57KwIFf{% endif %}"
+    icon-url="{{ site.baseurl }}/assets/Avatar-{{ icon }}-big.svg">
 </feedback-form>


### PR DESCRIPTION
Update feedback-form cdn version from 2.2.2 to latest 2.3.6

Includes fix for [this faulty behavior](https://stojan.tinytake.com/msc/OTExMTQzM18yMjYxODIzNg).