### PR TITLE
update verison to 4.7.2

### DIFF
--- a/_buildApi/BuildAPI/BuildAPI.csproj
+++ b/_buildApi/BuildAPI/BuildAPI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BuildAPI</RootNamespace>
     <AssemblyName>BuildAPI</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
After we moved from windows-2019 to windows-2022 the api project starts to fail since on  windows-2022 there is no Targetframework 4.0